### PR TITLE
[SPY-9410] Transmit MoPub consent to Ogury SDK.

### DIFF
--- a/Ogury/CHANGELOG.md
+++ b/Ogury/CHANGELOG.md
@@ -1,4 +1,4 @@
 ## Changelog
-  * 5.0.7.0
+  * 5.0.9.0
     * Initial commit
     * Add support for banner, interstitial and rewarded ads.

--- a/Ogury/build.gradle
+++ b/Ogury/build.gradle
@@ -1,4 +1,4 @@
-project.version = '5.0.7.0'
+project.version = '5.0.9.0'
 project.ext.networkName = 'ogury'
 
 apply from: '../shared-build.gradle'

--- a/Ogury/src/main/java/com/mopub/mobileads/OguryBanner.java
+++ b/Ogury/src/main/java/com/mopub/mobileads/OguryBanner.java
@@ -58,6 +58,7 @@ public class OguryBanner extends BaseAd implements OguryBannerAdListener {
         setAutomaticImpressionAndClickTracking(false);
 
         OguryInitializer.startOgurySDKIfNecessary(context, adData.getExtras());
+        OguryInitializer.updateConsent();
 
         mAdUnitId = OguryConfigurationParser.getAdUnitId(adData.getExtras());
         OguryBannerAdSize adSize = getBannerAdSize(adData.getAdWidth(), adData.getAdHeight());

--- a/Ogury/src/main/java/com/mopub/mobileads/OguryInitializer.java
+++ b/Ogury/src/main/java/com/mopub/mobileads/OguryInitializer.java
@@ -66,7 +66,7 @@ public class OguryInitializer {
         PersonalInfoManager personalInfoManager = MoPub.getPersonalInformationManager();
         if (personalInfoManager != null && personalInfoManager.gdprApplies()) {
             OguryChoiceManagerExternal.setConsent(
-                    personalInfoManager.canCollectPersonalInformation(),
+                    MoPub.canCollectPersonalInformation(),
                     CHOICE_MANAGER_CONSENT_ORIGIN
             );
         }

--- a/Ogury/src/main/java/com/mopub/mobileads/OguryInitializer.java
+++ b/Ogury/src/main/java/com/mopub/mobileads/OguryInitializer.java
@@ -64,11 +64,14 @@ public class OguryInitializer {
             return;
         }
         PersonalInfoManager personalInfoManager = MoPub.getPersonalInformationManager();
-        if (personalInfoManager != null && personalInfoManager.gdprApplies()) {
-            OguryChoiceManagerExternal.setConsent(
-                    MoPub.canCollectPersonalInformation(),
-                    CHOICE_MANAGER_CONSENT_ORIGIN
-            );
+        if (personalInfoManager != null) {
+            Boolean gdprApplies = personalInfoManager.gdprApplies();
+            if (gdprApplies != null && gdprApplies) {
+                OguryChoiceManagerExternal.setConsent(
+                        MoPub.canCollectPersonalInformation(),
+                        CHOICE_MANAGER_CONSENT_ORIGIN
+                );
+            }
         }
     }
 

--- a/Ogury/src/main/java/com/mopub/mobileads/OguryInitializer.java
+++ b/Ogury/src/main/java/com/mopub/mobileads/OguryInitializer.java
@@ -25,7 +25,7 @@ public class OguryInitializer {
     private static final String MONITORING_KEY_MODULE_VERSION = "mopub_ce_version";
     private static final String MONITORING_KEY_MOPUB_VERSION = "mopub_mediation_version";
 
-    private static final String CHOICE_MANAGER_CONSENT_ORIGIN = "MoPub";
+    private static final String CHOICE_MANAGER_CONSENT_ORIGIN = "MOPUB";
 
     private static boolean sInitialized = false;
 
@@ -66,7 +66,7 @@ public class OguryInitializer {
         PersonalInfoManager personalInfoManager = MoPub.getPersonalInformationManager();
         if (personalInfoManager != null && personalInfoManager.gdprApplies()) {
             OguryChoiceManagerExternal.setConsent(
-                    personalInfoManager.getPersonalInfoConsentStatus() == ConsentStatus.EXPLICIT_YES,
+                    personalInfoManager.canCollectPersonalInformation(),
                     CHOICE_MANAGER_CONSENT_ORIGIN
             );
         }

--- a/Ogury/src/main/java/com/mopub/mobileads/OguryInitializer.java
+++ b/Ogury/src/main/java/com/mopub/mobileads/OguryInitializer.java
@@ -8,7 +8,9 @@ import androidx.annotation.Nullable;
 import com.mopub.common.MoPub;
 import com.mopub.common.Preconditions;
 import com.mopub.common.logging.MoPubLog;
-import com.mopub.mobileads.ogury.BuildConfig;
+import com.mopub.common.privacy.ConsentStatus;
+import com.mopub.common.privacy.PersonalInfoManager;
+import com.ogury.cm.OguryChoiceManagerExternal;
 import com.ogury.sdk.Ogury;
 import com.ogury.sdk.OguryConfiguration;
 
@@ -22,6 +24,8 @@ public class OguryInitializer {
     // Monitoring constants
     private static final String MONITORING_KEY_MODULE_VERSION = "mopub_ce_version";
     private static final String MONITORING_KEY_MOPUB_VERSION = "mopub_mediation_version";
+
+    private static final String CHOICE_MANAGER_CONSENT_ORIGIN = "MoPub";
 
     private static boolean sInitialized = false;
 
@@ -55,9 +59,23 @@ public class OguryInitializer {
         startOgurySDK(context, assetKey);
     }
 
+    public static void updateConsent() {
+        if (!sInitialized) {
+            return;
+        }
+        PersonalInfoManager personalInfoManager = MoPub.getPersonalInformationManager();
+        if (personalInfoManager != null && personalInfoManager.gdprApplies()) {
+            OguryChoiceManagerExternal.setConsent(
+                    personalInfoManager.getPersonalInfoConsentStatus() == ConsentStatus.EXPLICIT_YES,
+                    CHOICE_MANAGER_CONSENT_ORIGIN
+            );
+        }
+    }
+
+
     /**
      * Retrieve MoPub version using reflection to know the exact version available in the application.
-     *
+     * <p>
      * Using the constant instead will make the compiler replace the value in the produced binary.
      * By using reflection, we are able to obtain the version integrated by the final user.
      *

--- a/Ogury/src/main/java/com/mopub/mobileads/OguryInterstitial.java
+++ b/Ogury/src/main/java/com/mopub/mobileads/OguryInterstitial.java
@@ -58,6 +58,7 @@ public class OguryInterstitial extends BaseAd implements OguryInterstitialAdList
         setAutomaticImpressionAndClickTracking(false);
 
         OguryInitializer.startOgurySDKIfNecessary(context, adData.getExtras());
+        OguryInitializer.updateConsent();
 
         mAdUnitId = OguryConfigurationParser.getAdUnitId(adData.getExtras());
         if (!OguryConfigurationParser.isAdUnitIdValid(mAdUnitId)) {

--- a/Ogury/src/main/java/com/mopub/mobileads/OguryRewardedVideo.java
+++ b/Ogury/src/main/java/com/mopub/mobileads/OguryRewardedVideo.java
@@ -61,6 +61,7 @@ public class OguryRewardedVideo extends BaseAd implements OguryOptinVideoAdListe
         setAutomaticImpressionAndClickTracking(false);
 
         OguryInitializer.startOgurySDKIfNecessary(context, adData.getExtras());
+        OguryInitializer.updateConsent();
 
         mAdUnitId = OguryConfigurationParser.getAdUnitId(adData.getExtras());
         if (!OguryConfigurationParser.isAdUnitIdValid(mAdUnitId)) {


### PR DESCRIPTION
# Description

Transmit MoPub consent to Ogury SDK:
- Consent is updated before every ad request.
- We consider only EXPLICIT_YES as an acceptance for our own consent.

Example:
```
{
	"assetType": "android",
	"assetKey": "OGY-690C2B3C5880",
	"deviceId": "37ff4101-1a52-42bf-a54c-df44d6fc2e70",
	"userConsent": {
		"status": true,
		"origin": "MoPub"
	}
}
```